### PR TITLE
Fix usage with reggae by deleting unused app.d file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ docs/
 
 # Code coverage
 *.lst
+
+
+struct-params-*

--- a/dub.json
+++ b/dub.json
@@ -8,10 +8,6 @@
   "name": "struct-params",
   "configurations": [
     {
-      "name": "application",
-      "targetType": "executable"
-    },
-    {
       "name": "shared-library",
       "targetType": "dynamicLibrary"
     },

--- a/source/app.d
+++ b/source/app.d
@@ -1,6 +1,0 @@
-import std.stdio;
-
-void main()
-{
-	writeln("Tests passed.");
-}


### PR DESCRIPTION
I could have also added `"excludedSourceFiles": ["source/app.d"]` to both library configurations, but given that the new `-unittest` behaviour doesn't even run the main function in app.d anyway, I thought it best to just delete it.

The existence of an un-namespaced `app` module in the resulting library can cause linker errors.