### PR TITLE
Fix usage with shlex library and D 2.095.1

### DIFF
--- a/source/struct_params.d
+++ b/source/struct_params.d
@@ -104,7 +104,7 @@ Note that we cannot use struct literals like `S.Regular(x: 11, y: 3.0)` in the c
 deprecated("Use the variant with both arguments *.WithDefaults")
 S.Regular combine(S)(S.WithDefaults main, S.Regular default_) {
     S.Regular result;
-    static foreach (m; __traits(allMembers, S.Regular)) {
+    static foreach (m; FieldNameTuple!(S.Regular)) {
         __traits(getMember, result, m) =
             __traits(getMember, main, m).isNull ? __traits(getMember, default_, m)
                                                 : __traits(getMember, main, m);
@@ -131,7 +131,7 @@ Note that we cannot use struct literals like `S.Regular(x: 11, y: 3.0)` in the c
 */
 S.Regular combine(S)(S.WithDefaults main, S.WithDefaults default_) {
     S.Regular result;
-    static foreach (m; __traits(allMembers, S.Regular)) {
+    static foreach (m; FieldNameTuple!(S.Regular)) {
         assert(!__traits(getMember, main, m).isNull || !__traits(getMember, default_, m).isNull);
         __traits(getMember, result, m) =
         __traits(getMember, main, m).isNull ? __traits(getMember, default_, m).get
@@ -159,7 +159,7 @@ Note that we cannot use struct literals like `S.Regular(x: 11, y: 3.0)` in the c
 */
 S.Regular combine(S)(S.WithDefaults main, S.Func default_) {
     S.Regular result;
-    static foreach (m; __traits(allMembers, S.Regular)) {
+    static foreach (m; FieldNameTuple!(S.Regular)) {
         assert(!__traits(getMember, main, m).isNull || !__traits(getMember, default_, m).isNull);
         __traits(getMember, result, m) =
         __traits(getMember, main, m).isNull ? __traits(getMember, default_, m).get()()


### PR DESCRIPTION
The `ShlexParams` struct contains a `Nullable!string` field: https://github.com/vporton/shlex-dlang/blob/3af05eb6cb31e8ea09386deba5c979694a0c043a/source/shlex.d#L459

`Nullable` got an `opAssign(Nullable)` with 2.095.1 (dlang/phobos#7759), and so does the `ShlexParams` struct. So `__traits(allMembers)` newly returns `opAssign` as well, and the assumption that the passed struct contains data members only doesn't hold anymore.